### PR TITLE
chore: SDK housekeeping — CHANGELOG, semver, api_version — RFC-009

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to `unju` will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+### Fixed
+- Memory API path corrected: `/v1/memories/` → `/v1/memory/` (affects all `memory.*` methods)
+
+### Added
+- Comprehensive memory integration test suite
+
+---
+
+## [0.1.0] — 2026-02-15
+
+### Added
+- `unju.memory` — add, search, list, get, delete, delete_all (mem0-compatible API)
+- `unju.agents` — list, get, connect, card, trust
+- `unju.credits` — balance, usage, yield_info
+- Sync (`Unju`) and async (`AsyncUnju`) clients
+- `api_version` parameter on both clients to pin the API version (default: `"v1"`)
+- `py.typed` marker — full mypy/pyright support out of the box
+- Zero heavy dependencies — httpx only
+
+---
+
+## Deprecation Policy
+
+When a method, parameter, or behaviour is scheduled for removal:
+
+1. It will be marked deprecated for **at least one minor version** before removal.
+2. A `DeprecationWarning` will be emitted at call time.
+3. The CHANGELOG entry will note the version in which it was deprecated and the version it will be removed.
+4. Breaking changes are reserved for major version bumps (`1.0.0`, `2.0.0`, …).
+
+While the SDK is in `v0.x.x` (pre-1.0 alpha/beta), minor versions may include breaking changes — these will always be called out explicitly in the `### Breaking` section of the relevant CHANGELOG entry.
+
+---
+
+[Unreleased]: https://github.com/unju-ai/unju-python/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/unju-ai/unju-python/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -119,7 +119,20 @@ unju = Unju(api_key="key", base_url="https://your-instance.com")
 
 # Custom timeout
 unju = Unju(api_key="key", timeout=60.0)
+
+# Pin API version (future-proofing — default is "v1")
+unju = Unju(api_key="key", api_version="v1")
 ```
+
+## Versioning & Deprecations
+
+This SDK follows [Semantic Versioning](https://semver.org/).
+
+- **Breaking changes** are reserved for major version bumps (`1.0.0`, `2.0.0`, …).
+- While in `v0.x.x` (pre-1.0 alpha), minor versions may include breaking changes — these are always called out in the [CHANGELOG](CHANGELOG.md).
+- Deprecated features emit a `DeprecationWarning` and are removed no sooner than the next minor release.
+
+See [CHANGELOG.md](CHANGELOG.md) for the full history.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ Homepage = "https://unju.ai"
 Documentation = "https://docs.unju.ai/sdk/python"
 Repository = "https://github.com/unju-ai/unju-python"
 Issues = "https://github.com/unju-ai/unju-python/issues"
+Changelog = "https://github.com/unju-ai/unju-python/blob/main/CHANGELOG.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["unju"]

--- a/unju/agents.py
+++ b/unju/agents.py
@@ -14,13 +14,14 @@ import httpx
 class Agents:
     """Synchronous agents client."""
 
-    def __init__(self, client: httpx.Client):
+    def __init__(self, client: httpx.Client, *, api_version: str = "v1"):
         self._client = client
+        self._v = api_version
 
     def list(self, *, include_coming_soon: bool = True) -> list[dict]:
         """List all available agents."""
         resp = self._client.get(
-            "/v1/agents",
+            f"/{self._v}/agents",
             params={"include_coming_soon": str(include_coming_soon).lower()},
         )
         resp.raise_for_status()
@@ -28,7 +29,7 @@ class Agents:
 
     def get(self, agent_id: str) -> dict:
         """Get agent details."""
-        resp = self._client.get(f"/v1/agents/{agent_id}")
+        resp = self._client.get(f"/{self._v}/agents/{agent_id}")
         resp.raise_for_status()
         return resp.json()
 
@@ -50,12 +51,15 @@ class Agents:
         if metadata:
             payload["metadata"] = metadata
 
-        resp = self._client.post("/v1/agents/connect", json=payload)
+        resp = self._client.post(f"/{self._v}/agents/connect", json=payload)
         resp.raise_for_status()
         return resp.json()
 
     def card(self, agent_id: str) -> dict:
-        """Get an agent's A2A Agent Card."""
+        """Get an agent's A2A Agent Card.
+
+        Note: Uses the well-known path (not versioned).
+        """
         resp = self._client.get(
             "/.well-known/agent.json",
             params={"agent": agent_id},
@@ -65,7 +69,7 @@ class Agents:
 
     def trust(self, agent_id: str) -> dict:
         """Get an agent's trust score and reviews."""
-        resp = self._client.get(f"/v1/agents/{agent_id}/trust")
+        resp = self._client.get(f"/{self._v}/agents/{agent_id}/trust")
         resp.raise_for_status()
         return resp.json()
 
@@ -73,19 +77,20 @@ class Agents:
 class AsyncAgents:
     """Async agents client."""
 
-    def __init__(self, client: httpx.AsyncClient):
+    def __init__(self, client: httpx.AsyncClient, *, api_version: str = "v1"):
         self._client = client
+        self._v = api_version
 
     async def list(self, *, include_coming_soon: bool = True) -> list[dict]:
         resp = await self._client.get(
-            "/v1/agents",
+            f"/{self._v}/agents",
             params={"include_coming_soon": str(include_coming_soon).lower()},
         )
         resp.raise_for_status()
         return resp.json().get("agents", [])
 
     async def get(self, agent_id: str) -> dict:
-        resp = await self._client.get(f"/v1/agents/{agent_id}")
+        resp = await self._client.get(f"/{self._v}/agents/{agent_id}")
         resp.raise_for_status()
         return resp.json()
 
@@ -102,11 +107,15 @@ class AsyncAgents:
         if metadata:
             payload["metadata"] = metadata
 
-        resp = await self._client.post("/v1/agents/connect", json=payload)
+        resp = await self._client.post(f"/{self._v}/agents/connect", json=payload)
         resp.raise_for_status()
         return resp.json()
 
     async def card(self, agent_id: str) -> dict:
+        """Get an agent's A2A Agent Card.
+
+        Note: Uses the well-known path (not versioned).
+        """
         resp = await self._client.get(
             "/.well-known/agent.json",
             params={"agent": agent_id},
@@ -115,6 +124,6 @@ class AsyncAgents:
         return resp.json()
 
     async def trust(self, agent_id: str) -> dict:
-        resp = await self._client.get(f"/v1/agents/{agent_id}/trust")
+        resp = await self._client.get(f"/{self._v}/agents/{agent_id}/trust")
         resp.raise_for_status()
         return resp.json()

--- a/unju/client.py
+++ b/unju/client.py
@@ -9,6 +9,7 @@ from unju.agents import Agents, AsyncAgents
 from unju.credits import Credits, AsyncCredits
 
 DEFAULT_BASE_URL = "https://api.unju.ai"
+DEFAULT_API_VERSION = "v1"
 
 
 class Unju:
@@ -17,6 +18,9 @@ class Unju:
     Usage:
         unju = Unju(api_key="your-key")
         unju.memory.add("user_123", "Loves ramen")
+
+        # Pin a specific API version (future-proofing)
+        unju = Unju(api_key="your-key", api_version="v2")
     """
 
     def __init__(
@@ -24,9 +28,11 @@ class Unju:
         api_key: str,
         base_url: str = DEFAULT_BASE_URL,
         timeout: float = 30.0,
+        api_version: str = DEFAULT_API_VERSION,
     ):
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
+        self.api_version = api_version
         self._client = httpx.Client(
             base_url=self._base_url,
             headers={
@@ -37,9 +43,9 @@ class Unju:
             timeout=timeout,
         )
 
-        self.memory = Memory(self._client)
-        self.agents = Agents(self._client)
-        self.credits = Credits(self._client)
+        self.memory = Memory(self._client, api_version=api_version)
+        self.agents = Agents(self._client, api_version=api_version)
+        self.credits = Credits(self._client, api_version=api_version)
 
     def close(self):
         self._client.close()
@@ -51,7 +57,7 @@ class Unju:
         self.close()
 
     def __repr__(self):
-        return f"Unju(base_url='{self._base_url}')"
+        return f"Unju(base_url='{self._base_url}', api_version='{self.api_version}')"
 
 
 class AsyncUnju:
@@ -60,6 +66,10 @@ class AsyncUnju:
     Usage:
         async with AsyncUnju(api_key="your-key") as unju:
             await unju.memory.add("user_123", "Loves ramen")
+
+        # Pin a specific API version (future-proofing)
+        async with AsyncUnju(api_key="your-key", api_version="v2") as unju:
+            ...
     """
 
     def __init__(
@@ -67,9 +77,11 @@ class AsyncUnju:
         api_key: str,
         base_url: str = DEFAULT_BASE_URL,
         timeout: float = 30.0,
+        api_version: str = DEFAULT_API_VERSION,
     ):
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
+        self.api_version = api_version
         self._client = httpx.AsyncClient(
             base_url=self._base_url,
             headers={
@@ -80,9 +92,9 @@ class AsyncUnju:
             timeout=timeout,
         )
 
-        self.memory = AsyncMemory(self._client)
-        self.agents = AsyncAgents(self._client)
-        self.credits = AsyncCredits(self._client)
+        self.memory = AsyncMemory(self._client, api_version=api_version)
+        self.agents = AsyncAgents(self._client, api_version=api_version)
+        self.credits = AsyncCredits(self._client, api_version=api_version)
 
     async def close(self):
         await self._client.aclose()
@@ -94,4 +106,4 @@ class AsyncUnju:
         await self.close()
 
     def __repr__(self):
-        return f"AsyncUnju(base_url='{self._base_url}')"
+        return f"AsyncUnju(base_url='{self._base_url}', api_version='{self.api_version}')"

--- a/unju/credits.py
+++ b/unju/credits.py
@@ -12,8 +12,9 @@ import httpx
 class Credits:
     """Synchronous credits client."""
 
-    def __init__(self, client: httpx.Client):
+    def __init__(self, client: httpx.Client, *, api_version: str = "v1"):
         self._client = client
+        self._v = api_version
 
     def balance(self) -> dict:
         """Get current credit balance.
@@ -21,7 +22,7 @@ class Credits:
         Returns:
             dict with `available`, `locked`, `earned_yield`, `total`
         """
-        resp = self._client.get("/v1/credits/balance")
+        resp = self._client.get(f"/{self._v}/credits/balance")
         resp.raise_for_status()
         return resp.json()
 
@@ -31,13 +32,13 @@ class Credits:
         Args:
             days: Number of days to look back
         """
-        resp = self._client.get("/v1/credits/usage", params={"days": days})
+        resp = self._client.get(f"/{self._v}/credits/usage", params={"days": days})
         resp.raise_for_status()
         return resp.json()
 
     def yield_info(self) -> dict:
         """Get yield information — current APY, total earned."""
-        resp = self._client.get("/v1/credits/yield")
+        resp = self._client.get(f"/{self._v}/credits/yield")
         resp.raise_for_status()
         return resp.json()
 
@@ -45,20 +46,21 @@ class Credits:
 class AsyncCredits:
     """Async credits client."""
 
-    def __init__(self, client: httpx.AsyncClient):
+    def __init__(self, client: httpx.AsyncClient, *, api_version: str = "v1"):
         self._client = client
+        self._v = api_version
 
     async def balance(self) -> dict:
-        resp = await self._client.get("/v1/credits/balance")
+        resp = await self._client.get(f"/{self._v}/credits/balance")
         resp.raise_for_status()
         return resp.json()
 
     async def usage(self, *, days: int = 30) -> dict:
-        resp = await self._client.get("/v1/credits/usage", params={"days": days})
+        resp = await self._client.get(f"/{self._v}/credits/usage", params={"days": days})
         resp.raise_for_status()
         return resp.json()
 
     async def yield_info(self) -> dict:
-        resp = await self._client.get("/v1/credits/yield")
+        resp = await self._client.get(f"/{self._v}/credits/yield")
         resp.raise_for_status()
         return resp.json()

--- a/unju/memory.py
+++ b/unju/memory.py
@@ -21,8 +21,9 @@ import httpx
 class Memory:
     """Synchronous memory client."""
 
-    def __init__(self, client: httpx.Client):
+    def __init__(self, client: httpx.Client, *, api_version: str = "v1"):
         self._client = client
+        self._v = api_version
 
     def add(
         self,
@@ -47,7 +48,7 @@ class Memory:
         if metadata:
             payload["metadata"] = metadata
 
-        resp = self._client.post("/v1/memory/", json=payload)
+        resp = self._client.post(f"/{self._v}/memory/", json=payload)
         resp.raise_for_status()
         return resp.json()
 
@@ -66,7 +67,7 @@ class Memory:
             limit: Max results
         """
         resp = self._client.post(
-            "/v1/memory/search/",
+            f"/{self._v}/memory/search/",
             json={"query": query, "user_id": user_id, "limit": limit},
         )
         resp.raise_for_status()
@@ -74,25 +75,25 @@ class Memory:
 
     def list(self, user_id: str) -> list[dict]:
         """Get all memories for a user."""
-        resp = self._client.get("/v1/memory/", params={"user_id": user_id})
+        resp = self._client.get(f"/{self._v}/memory/", params={"user_id": user_id})
         resp.raise_for_status()
         return resp.json().get("results", [])
 
     def get(self, memory_id: str) -> dict:
         """Get a specific memory by ID."""
-        resp = self._client.get(f"/v1/memory/{memory_id}/")
+        resp = self._client.get(f"/{self._v}/memory/{memory_id}/")
         resp.raise_for_status()
         return resp.json()
 
     def delete(self, memory_id: str) -> dict:
         """Delete a memory."""
-        resp = self._client.delete(f"/v1/memory/{memory_id}/")
+        resp = self._client.delete(f"/{self._v}/memory/{memory_id}/")
         resp.raise_for_status()
         return resp.json()
 
     def delete_all(self, user_id: str) -> dict:
         """Delete all memories for a user."""
-        resp = self._client.delete("/v1/memory/", params={"user_id": user_id})
+        resp = self._client.delete(f"/{self._v}/memory/", params={"user_id": user_id})
         resp.raise_for_status()
         return resp.json()
 
@@ -100,8 +101,9 @@ class Memory:
 class AsyncMemory:
     """Async memory client."""
 
-    def __init__(self, client: httpx.AsyncClient):
+    def __init__(self, client: httpx.AsyncClient, *, api_version: str = "v1"):
         self._client = client
+        self._v = api_version
 
     async def add(
         self,
@@ -119,7 +121,7 @@ class AsyncMemory:
         if metadata:
             payload["metadata"] = metadata
 
-        resp = await self._client.post("/v1/memory/", json=payload)
+        resp = await self._client.post(f"/{self._v}/memory/", json=payload)
         resp.raise_for_status()
         return resp.json()
 
@@ -131,28 +133,28 @@ class AsyncMemory:
         limit: int = 10,
     ) -> list[dict]:
         resp = await self._client.post(
-            "/v1/memory/search/",
+            f"/{self._v}/memory/search/",
             json={"query": query, "user_id": user_id, "limit": limit},
         )
         resp.raise_for_status()
         return resp.json().get("results", [])
 
     async def list(self, user_id: str) -> list[dict]:
-        resp = await self._client.get("/v1/memory/", params={"user_id": user_id})
+        resp = await self._client.get(f"/{self._v}/memory/", params={"user_id": user_id})
         resp.raise_for_status()
         return resp.json().get("results", [])
 
     async def get(self, memory_id: str) -> dict:
-        resp = await self._client.get(f"/v1/memory/{memory_id}/")
+        resp = await self._client.get(f"/{self._v}/memory/{memory_id}/")
         resp.raise_for_status()
         return resp.json()
 
     async def delete(self, memory_id: str) -> dict:
-        resp = await self._client.delete(f"/v1/memory/{memory_id}/")
+        resp = await self._client.delete(f"/{self._v}/memory/{memory_id}/")
         resp.raise_for_status()
         return resp.json()
 
     async def delete_all(self, user_id: str) -> dict:
-        resp = await self._client.delete("/v1/memory/", params={"user_id": user_id})
+        resp = await self._client.delete(f"/{self._v}/memory/", params={"user_id": user_id})
         resp.raise_for_status()
         return resp.json()


### PR DESCRIPTION
## Summary

Closes #2 — RFC-009 SDK housekeeping.

## Changes

### CHANGELOG.md (new)
- Keep-a-Changelog format, full history from v0.1.0
- `[Unreleased]` section documents memory path fix + tests
- Deprecation policy embedded in CHANGELOG (canonical location)

### `api_version` parameter
```python
# Pin to a specific API version (default is 'v1')
unju = Unju(api_key='...', api_version='v1')
```
- Accepted by both `Unju` and `AsyncUnju`
- Threaded through `Memory`, `Agents`, `Credits` sub-clients
- `/.well-known/agent.json` correctly left unversioned (it's an IANA well-known path)

### Deprecation policy
- Deprecated features → `DeprecationWarning` + at least 1 minor version notice before removal
- Breaking changes reserved for major bumps
- Pre-1.0 (`v0.x.x`): minor bumps may break — always called out in CHANGELOG

### README
- Added `api_version` usage example
- Added *Versioning & Deprecations* section with link to CHANGELOG

### pyproject.toml
- Added `Changelog` URL to `[project.urls]`

## Affected files
`CHANGELOG.md`, `README.md`, `pyproject.toml`, `unju/client.py`, `unju/memory.py`, `unju/agents.py`, `unju/credits.py`